### PR TITLE
Speed up CI runs by using cache and local binary

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -21,3 +21,4 @@ jobs:
       uses: actions/checkout@v2
     - name: Test
       run: go test ./web/api
+

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -10,6 +10,13 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.14.x
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -10,10 +10,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.14.x
-    - name: GitHub Action for Homebrew
-      uses: artemnovichkov/action-homebrew@0.1.0
-    - name: Install oauth2l
-      run: brew install oauth2l
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test

--- a/web/api/wrapper.go
+++ b/web/api/wrapper.go
@@ -45,7 +45,7 @@ func (wc WrapperCommand) Execute() (output string, err error) {
 	}
 
 	// Execute command and capture output
-	command := exec.Command("oauth2l", args...)
+	command := exec.Command("./binaries/oauth2l", args...)
 	byteBuffer, err := command.Output()
 
 	// Convert byteBuffer to string and remove newline character


### PR DESCRIPTION
This PR speeds up the API CI runs by about 93% (290s to 19s)