### PR TITLE
Token for multiple scopes.

### DIFF
--- a/client/src/components/form/TokenForm.jsx
+++ b/client/src/components/form/TokenForm.jsx
@@ -126,7 +126,7 @@ export default function TokenForm(props) {
     if (values.tokenScopes.length === 0) {
       userAudience = values.tokenAudience;
     } else {
-      userScopes = values.tokenScopes;
+      userScopes = values.tokenScopes.join(",");
     }
     let userFormat;
     if (values.tokenFormat === "JSON Compact") {


### PR DESCRIPTION
Hey there!
I've noticed that this UI tool generates the wrong URL for token retrieving.
The [oauth2l](https://github.com/google/oauth2l) expects to get a string with comma-separated scopes, but you are passing an array itself.
As a result, it is impossible to get a token for multiple scopes.
This PR fixes this bug.